### PR TITLE
fix awk  warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ help:
 	@echo ' make [target]'
 	@echo ''
 	@echo 'Targets:'
-	@awk '/^[a-zA-Z\-\_0-9]+:/ { \
+	@awk '/^[a-zA-Z\-_0-9]+:/ { \
 	helpMessage = match(lastLine, /^# (.*)/); \
 		if (helpMessage) { \
 			helpCommand = substr($$1, 0, index($$1, ":")-1); \


### PR DESCRIPTION
fix awk warning : regexp escape sequence '\_' is not a known regexp operator